### PR TITLE
Refactored sendposts functionality into separate Facebook and Twitter handlers

### DIFF
--- a/meow/scheduler/management/commands/sendfacebook.py
+++ b/meow/scheduler/management/commands/sendfacebook.py
@@ -1,0 +1,111 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
+from django.utils import timezone
+from django.conf import settings
+
+from datetime import datetime, timedelta
+from facepy import GraphAPI
+from facepy.exceptions import FacepyError
+import re
+import io
+import requests
+import json
+import sys
+import time
+import traceback
+
+from scheduler.models import MeowSetting, SMPost
+
+class Command(BaseCommand):
+    help = "Sends the appropriate Facebook post"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--smpost', default=None,
+            help="Post to tweet out.")
+        parser.add_argument(
+            '--section', default=None,
+            help="Section of post.")
+        parser.add_argument(
+            '--url', default=None,
+            help="URL to post.")
+        parser.add_argument(
+            '--photo_url', default=None,
+            help="URL to accompanying photo.")
+        parser.add_argument(
+            '--fb_default_photo', default=None,
+            help="URL to photo to display on Facebook.")
+
+
+    def handle(self, *args, **options):
+        smpost = options.get('smpost', None)
+        section = options.get('section', None)
+        url = options.get('url', None)
+        photo_url = options.get('photo_url', None)
+        fb_default_photo = options.get('fb_default_photo', None)
+
+        try:
+            print('Sending FB: {}'.format(smpost.post_facebook))
+            # follow these steps: http://stackoverflow.com/questions/17620266/getting-a-manage-page-access-token-to-upload-events-to-a-facebook-page
+            # Facebook needs the following permissions:
+            # status_update, manage_pages
+
+            # Initialize the Graph API with a valid access token (optional,
+            # but will allow you to do all sorts of fun stuff).
+
+            # Get token from here: https://developers.facebook.com/docs/opengraph/howtos/publishing-with-app-token/
+            # appGraph = GraphAPI('72296391616|_vtz8ShgOfzLSgKeDw2quIS1pCc')
+            GRAPH_KEY = section.facebook_key
+            graph = GraphAPI(GRAPH_KEY)  # This should not expire
+
+            PAGE_ID = section.facebook_page_id
+
+            data = {
+                "path": PAGE_ID + '/feed',
+                "message": smpost.post_facebook,
+            }
+            if photo_url:
+                data['picture'] = photo_url
+            else:
+                data['picture'] = fb_default_photo
+            
+            if url:
+                data['link'] = url
+
+            errors = 0
+            res = None
+            while errors < 2:
+                try:
+                    res = graph.post(**data)
+                    break
+                except Exception as e:
+                    smpost.log("Facebook Errored - #%d attempt. Msg:\n %s \n Traceback:\n %s" % (errors, e, traceback.format_exc()))
+                    if errors >= 2:
+                        raise Exception
+                        break
+                    else:
+                        time.sleep(0.5)
+                        errors += 1
+
+            print("----------------------")
+            post_id = res['id'].split('_')[1]
+            print("Successfully posted to FB at ID: %s" % post_id)
+
+            # Add the id for the post to the database
+            smpost.id_facebook = post_id
+            smpost.save()
+
+            return "https://facebook.com/{}".format(post_id)
+
+        except (FacepyError) as e:
+            smpost.log(traceback.format_exc())
+            smpost.log_error(e, section, True)
+            slack_data = {
+                "text": ":sadparrot: *{}* has errored at {}"
+                .format(smpost.slug, timezone.now().strftime("%A, %d. %B %Y %I:%M%p")),
+                "attachments": [{"color": "danger", "title": "Facebook Error", "text": str(e)}]
+            }
+
+            requests.post(settings.SLACK_ENDPOINT,
+                          data=json.dumps(slack_data),
+                          headers={'Content-Type': 'application/json'})

--- a/meow/scheduler/management/commands/sendtweet.py
+++ b/meow/scheduler/management/commands/sendtweet.py
@@ -1,0 +1,91 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.core.management import call_command
+from django.utils import timezone
+from django.conf import settings
+
+from datetime import datetime, timedelta
+import tweepy
+import re
+import io
+import requests
+import json
+import sys
+import time
+import traceback
+
+from scheduler.models import MeowSetting, SMPost
+
+class Command(BaseCommand):
+    help = "Sends the appropriate tweet"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--smpost', default=None,
+            help="Post to tweet out.")
+        parser.add_argument(
+            '--section', default=None,
+            help="Section of post.")
+        parser.add_argument(
+            '--url', default=None,
+            help="URL to post.")
+        parser.add_argument(
+            '--photo_url', default=None,
+            help="URL to accompanying photo.")
+
+
+    def handle(self, *args, **options):
+        smpost = options.get('smpost', None)
+        section = options.get('section', None)
+        url = options.get('url', None)
+        photo_url = options.get('photo_url', None)
+        try:
+            print('Sending Tweet: {}'.format(smpost.post_twitter))
+            CONSUMER_KEY = MeowSetting.objects.get(
+                setting_key='twitter_consumer_key').setting_value
+            CONSUMER_SECRET = MeowSetting.objects.get(
+                setting_key='twitter_consumer_secret').setting_value
+            ACCESS_KEY = section.twitter_access_key
+            ACCESS_SECRET = section.twitter_access_secret
+
+            auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
+            auth.set_access_token(ACCESS_KEY, ACCESS_SECRET)
+
+            api = tweepy.API(auth)
+
+            # Make the tweet follow DB social media standards
+            tweet = smpost.post_twitter
+
+            if url is not None:
+                tweet = tweet + " " + url
+
+            if photo_url is not None:
+                photo_source = requests.get(photo_url)
+                filename = re.search("/([^/]*)$", photo_source.url).group(1)
+                # io is needed to make an actual file object (tweepy requires
+                # the seek method on the file object)
+                photo_fd = io.BytesIO(photo_source.content)
+                res = api.update_with_media(filename, tweet, file=photo_fd)
+            else:
+                res = api.update_status(status=tweet)
+
+            print("----------------------")
+            print(res.id)
+
+            # Add the id for the post to the database
+            smpost.id_twitter = res.id
+            smpost.save()
+
+            return "https://twitter.com/statuses/{}".format(res.id)
+
+        except tweepy.TweepError as e:
+            smpost.log(traceback.format_exc())
+            smpost.log_error(e, section, True)
+            slack_data = {
+                "text": ":sadparrot: *{}* has errored at {}"
+                .format(smpost.slug, timezone.localtime(timezone.now()).strftime("%A, %d. %B %Y %I:%M%p")),
+                "attachments": [{"color": "danger", "title": "Twitter Error", "text": str(e)}]
+            }
+
+            requests.post(settings.SLACK_ENDPOINT,
+                          data=json.dumps(slack_data),
+                          headers={'Content-Type': 'application/json'})


### PR DESCRIPTION
## Description
Moved the `sendTweet` and `sendFacebookPost` functions out of the `sendposts.py` file and into their own commands within the same `/commands` directory. This should help to reduce the complexity and improve the maintainability of the post sending functionality.

## Issues
There is still room for improvement to move fetching/getting the posts to send into its own command `getposts.py`, however, I am delaying that until we make sure this PR works.

Addresses #171 and #134 