### PR TITLE
Sign out on `/user/me` failure

### DIFF
--- a/meow/frontend/src/actions/user.js
+++ b/meow/frontend/src/actions/user.js
@@ -41,18 +41,12 @@ export const login = () => {
 };
 
 export const logout = () => dispatch => {
-  return apiLogout()
-    .then(() => {
-      dispatch({
-        type: "LOGOUT"
-      });
-    })
-    .catch(err => {
-      dispatch({
-        type: "NETWORK_ERROR",
-        message: "Could not connect to server."
-      });
-    });
+  // We logout frontend no matter what heppens
+  dispatch({
+    type: "LOGOUT"
+  });
+  // we don't care what returns from server
+  apiLogout();
 };
 
 export const getUser = username => {

--- a/meow/frontend/src/actions/user.js
+++ b/meow/frontend/src/actions/user.js
@@ -48,52 +48,48 @@ export const logout = () => dispatch => {
 
 export const getUser = username => {
   return dispatch => {
-    return userDetail(username).then(
-      ({ data, status }) => {
-        if (status >= 400) {
+    return userDetail(username)
+      .then(({ data }) => data)
+      .catch(err => {
+        const { status } = err.response;
+        if (status >= 400 && status < 500)
           dispatch({
             type: "PROFILE_FAIL",
             message: `Could not get specified user "${username}"`
           });
-        } else {
-          return data;
-        }
-      },
-      err => {
-        dispatch({
-          type: "NETWORK_ERROR",
-          message: "Could not connect to server."
-        });
-      }
-    );
+        else
+          dispatch({
+            type: "NETWORK_ERROR",
+            message: "Could not connect to server."
+          });
+      });
   };
 };
 
 export const editUser = newData => dispatch => {
-  return putUser(newData).then(
-    ({ data, status }) => {
-      if (status >= 400) {
+  return putUser(newData)
+    .then(({ data }) => {
+      if (newData.selected_theme) {
+        dispatch({
+          type: "THEME_CHANGE",
+          payload: {
+            theme: newData.selected_theme
+          }
+        });
+      }
+      return data;
+    })
+    .catch(err => {
+      const { status } = err.response;
+      if (status >= 400 && status < 500)
         dispatch({
           type: "EDIT_USER_FAIL",
           message: `Could not edit current user"`
         });
-      } else {
-        if (newData.selected_theme) {
-          dispatch({
-            type: "THEME_CHANGE",
-            payload: {
-              theme: newData.selected_theme
-            }
-          });
-        }
-        return data;
-      }
-    },
-    err => {
-      dispatch({
-        type: "NETWORK_ERROR",
-        message: "Could not connect to server."
-      });
-    }
-  );
+      else
+        dispatch({
+          type: "NETWORK_ERROR",
+          message: "Could not connect to server."
+        });
+    });
 };

--- a/meow/frontend/src/actions/user.js
+++ b/meow/frontend/src/actions/user.js
@@ -12,31 +12,28 @@ const loginSuccess = ({ username, firstName, isAuthenticated, theme }) => ({
 
 export const login = () => {
   return dispatch => {
-    return getMe().then(
-      ({ data, status }) => {
-        if (status >= 400) {
-          dispatch({
-            type: "USER_LOGIN_FAIL",
-            message: "Could not get current user."
-          });
-        } else {
-          dispatch(
-            loginSuccess({
-              username: data.username,
-              firstName: data.first_name,
-              theme: data.theme,
-              isAuthenticated: true
-            })
-          );
-        }
-      },
-      err => {
+    return getMe()
+      .then(({ data }) => {
+        dispatch(
+          loginSuccess({
+            username: data.username,
+            firstName: data.first_name,
+            theme: data.theme,
+            isAuthenticated: true
+          })
+        );
+      })
+      .catch(err => {
         dispatch({
-          type: "NETWORK_ERROR",
-          message: "Could not connect to server."
+          type: "USER_LOGIN_FAIL",
+          message: "Could not get current user."
         });
-      }
-    );
+        if (err.response.status >= 500)
+          dispatch({
+            type: "NETWORK_ERROR",
+            message: "Could not connect to server."
+          });
+      });
   };
 };
 

--- a/meow/frontend/src/components/EditPost/index.js
+++ b/meow/frontend/src/components/EditPost/index.js
@@ -14,6 +14,8 @@ import { getMe } from "../../services/api";
 
 import { getPost, editPost, savePost, sendPostNow } from "../../actions/post";
 
+import { logout } from "../../actions/user";
+
 import { loadSections } from "../../actions/section";
 
 const { Content } = Layout;
@@ -27,12 +29,17 @@ class EditPost extends React.Component {
   componentDidMount() {
     const { postId } = this.props.match.params;
 
-    getMe().then(res => {
-      console.log(res.data);
-      this.setState({
-        user_groups: res.data.groups
+    getMe()
+      .then(res => {
+        console.log(res.data);
+        this.setState({
+          user_groups: res.data.groups
+        });
+      })
+      .catch(err => {
+        // any error we logout
+        this.props.logout();
       });
-    });
 
     if (postId) {
       this.props.getPost(postId).then(data => {
@@ -160,7 +167,8 @@ const mapDispatchToProps = {
   loadSections,
   editPost: data => editPost(data),
   savePost: (postId, postData) => savePost(postId, postData),
-  sendPostNow: postId => sendPostNow(postId)
+  sendPostNow: postId => sendPostNow(postId),
+  logout
 };
 
 export default withRouter(

--- a/meow/frontend/src/components/Posts/Content.js
+++ b/meow/frontend/src/components/Posts/Content.js
@@ -133,7 +133,9 @@ class Posts extends React.Component {
             rowKey="id"
             dataSource={this.props.data}
             columns={this.state.columns}
-            onRowClick={record => this.props.history.push(`/edit/${record.id}`)}
+            onRowClick={record => {
+              onClick: () => this.props.history.push(`/edit/${record.id}`);
+            }}
             rowClassName={record => {
               if (record.sent_error) return "sent-error";
               if (record.sending) return "sending";


### PR DESCRIPTION
fix #250 

A few things to note:
- the `logout` action now directly dispatch, a `logout` is dispatch. Now, it does not care about the server response. 
- all the actions within `user` are now fixed. Previously, the `then` block also handles 400, 500 response code, which is actually unreachable code since axios throws error on those cases. Now, those cases are handled in the `catch` block. 
- the `onRow` deprecation warning is now fixed. 