### PR TITLE
Implemented Search Bar to Search Slugs

### DIFF
--- a/meow/frontend/src/components/Header/index.js
+++ b/meow/frontend/src/components/Header/index.js
@@ -1,17 +1,18 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
-import { Button } from "antd";
+import { Button, Input } from "antd";
 import "./index.css";
 import SettingsButton from "./SettingsButton";
 import config from "../../config";
+import { setSearchTerm } from "../../reducers/post";
 
 const options = { month: "long", day: "2-digit", hour: "2-digit", minute: "2-digit" };
 
 class Header extends Component {
   state = {
-    time: new Date().toLocaleString("en-US", options),
-    showNewmeow: null
+    showNewmeow: null,
+    searchTerm: ""
   };
 
   componentDidMount() {
@@ -21,11 +22,6 @@ class Header extends Component {
         this.props.location.pathname.substring(0, 5) === "/edit"
       )
     });
-    setInterval(() => {
-      this.setState({
-        time: new Date().toLocaleString("en-US", options)
-      });
-    }, 1000);
   }
 
   newmeow = () => {
@@ -44,6 +40,12 @@ class Header extends Component {
 
   toMe = () => {
     this.props.history.push("/me");
+  };
+
+  handleSearch = e => {
+    const term = e.target.value;
+    this.setState({ searchTerm: term });
+    this.props.setSearchTerm(term);
   };
 
   render() {
@@ -83,11 +85,14 @@ class Header extends Component {
         >
           {"meow"}
         </h1>
-        {this.props.device === config.MOBILE ? null : (
-          <h2 style={{ color: `${this.props.theme.primary_font_color}` }}>
-            today: {this.state.time}
-          </h2>
-        )}
+        {this.state.showNewmeow ? (
+          <Input
+            placeholder="Search slug…"
+            style={{ width: "550px", height: "40px", borderRadius: "2px", margin: "0 1em" }}
+            value={this.state.searchTerm}
+            onChange={this.handleSearch}
+          />
+        ) : null}
         {this.state.showNewmeow ? (
           <div>
             <span onClick={this.toMe} style={{ fontSize: "1.3em", cursor: "pointer" }}>
@@ -121,7 +126,8 @@ const mapStateToProps = state => ({
   username: state.default.user.username,
   firstName: state.default.user.firstName,
   theme: state.default.user.theme,
-  device: state.default.mobile.device
+  device: state.default.mobile.device,
+  searchTerm: state.default.post.searchTerm
 });
 
 const mapDispatchToProps = {
@@ -132,7 +138,8 @@ const mapDispatchToProps = {
         theme: new_theme
       }
     });
-  }
+  },
+  setSearchTerm
 };
 
 export default withRouter(

--- a/meow/frontend/src/components/Header/index.js
+++ b/meow/frontend/src/components/Header/index.js
@@ -88,7 +88,7 @@ class Header extends Component {
         {this.state.showNewmeow ? (
           <Input
             placeholder="Search slug…"
-            style={{ width: "550px", height: "40px", borderRadius: "2px", margin: "0 1em" }}
+            style={{ width: "750px", height: "40px", borderRadius: "12px", margin: "0 1em" }}
             value={this.state.searchTerm}
             onChange={this.handleSearch}
           />

--- a/meow/frontend/src/components/Posts/Sidebar.js
+++ b/meow/frontend/src/components/Posts/Sidebar.js
@@ -3,18 +3,34 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router-dom";
 import { Collapse, Calendar, Checkbox } from "antd";
 import moment from "moment";
-
+import config from "../../config";
 import { logout } from "../../actions/user";
-
 import "./Sidebar.css";
 import TimeSlider from "./TimeSlider";
 import { FiChevronRight, FiRotateCcw } from "react-icons/fi";
 const { Panel } = Collapse;
 
+const timeOptions = { month: "long", day: "2-digit", hour: "2-digit", minute: "2-digit" };
+
 class Sidebar extends React.Component {
+  state = {
+    time: new Date().toLocaleString("en-US", timeOptions)
+  };
   constructor(props) {
     super(props);
     this.editParent = this.props.editParent.bind(this);
+  }
+
+  componentDidMount() {
+    this.timer = setInterval(() => {
+      this.setState({
+        time: new Date().toLocaleString("en-US", timeOptions)
+      });
+    }, 1000);
+  }
+
+  componentWillUnmount() {
+    clearInterval(this.timer);
   }
 
   logout = () => {
@@ -208,6 +224,16 @@ class Sidebar extends React.Component {
             </Checkbox>
           </Panel>
         </Collapse>
+        {this.props.device !== config.MOBILE && (
+          <h3
+            style={{
+              marginLeft: "15px",
+              color: this.props.theme.secondary_font_color
+            }}
+          >
+            today: {this.state.time}
+          </h3>
+        )}
         <div
           onClick={this.logout}
           style={{
@@ -238,7 +264,8 @@ class Sidebar extends React.Component {
 
 const mapStateToProps = state => ({
   sections: state.default.section.sections,
-  theme: state.default.user.theme
+  theme: state.default.user.theme,
+  device: state.default.mobile.device
 });
 
 const mapDispatchToProps = {

--- a/meow/frontend/src/components/Posts/Sidebar.js
+++ b/meow/frontend/src/components/Posts/Sidebar.js
@@ -227,7 +227,7 @@ class Sidebar extends React.Component {
         {this.props.device !== config.MOBILE && (
           <h3
             style={{
-              marginLeft: "15px",
+              alignSelf: "center",
               color: this.props.theme.secondary_font_color
             }}
           >

--- a/meow/frontend/src/components/Posts/index.js
+++ b/meow/frontend/src/components/Posts/index.js
@@ -59,22 +59,33 @@ class Posts extends React.Component {
   }
 
   filterPosts = () => {
+    let results = dataStore;
+
     const { time, status, section } = this.state.query;
 
-    if (!(time || status.length || section.length)) {
-      return dataStore;
+    if (time || status.length || section.length) {
+      results = results.filter(
+        x =>
+          (time ? x.pub_time > time : true) &&
+          (status.length && status.includes("READY") ? x.pub_ready_online : true) &&
+          (status.length && status.includes("DRAFT")
+            ? !(x.pub_ready_online || x.pub_ready_copy)
+            : true) &&
+          (status.length && status.includes("SENT") ? x.sent : true) &&
+          (section.length ? section.includes(x.section) : true)
+      );
     }
 
-    return dataStore.filter(
-      x =>
-        (time ? x.pub_time > time : true) &&
-        (status.length && status.includes("READY") ? x.pub_ready_online : true) &&
-        (status.length && status.includes("DRAFT")
-          ? !(x.pub_ready_online || x.pub_ready_copy)
-          : true) &&
-        (status.length && status.includes("SENT") ? x.sent : true) &&
-        (section.length ? section.includes(x.section) : true)
-    );
+    const { searchTerm } = this.props;
+    if (searchTerm && searchTerm.trim()) {
+      const term = searchTerm.toLowerCase();
+      results = results.filter(post => {
+        const slug = (post.slug || "").toLowerCase();
+        return slug.includes(term);
+      });
+    }
+
+    return results;
   };
 
   queryChanged = change => {
@@ -115,7 +126,8 @@ class Posts extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  device: state.default.mobile.device
+  device: state.default.mobile.device,
+  searchTerm: state.default.post.searchTerm
 });
 
 const mapDispatchToProps = {

--- a/meow/frontend/src/reducers/post.js
+++ b/meow/frontend/src/reducers/post.js
@@ -1,4 +1,15 @@
-const initialState = { slug: "" };
+const initialState = {
+  slug: "",
+  searchTerm: ""
+};
+
+export const SET_SEARCH_TERM = "SET_SEARCH_TERM";
+
+export const setSearchTerm = term => ({
+  type: SET_SEARCH_TERM,
+  payload: term
+});
+
 export default function post(state = initialState, action) {
   switch (action.type) {
     case "FETCH_POST_SUCCESS":
@@ -18,6 +29,11 @@ export default function post(state = initialState, action) {
       return {
         ...state,
         ...action.payload
+      };
+    case SET_SEARCH_TERM:
+      return {
+        ...state,
+        searchTerm: action.payload
       };
     default:
       return state;

--- a/meow/meow/settings.py
+++ b/meow/meow/settings.py
@@ -15,9 +15,9 @@ DEBUG = env('DEBUG')
 SLACK_ENDPOINT = env('SLACK_ENDPOINT')
 
 if not DEBUG:
-    ALLOWED_HOSTS = [env('SITE_HOST'), ]
+    ALLOWED_HOSTS = [env('SITE_HOST'), '0.0.0.0']
 else:
-    ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]']
+    ALLOWED_HOSTS = ['localhost', '127.0.0.1', '[::1]', '0.0.0.0']
 
 # ALLOWED_HOSTS=['*']
 # print(ALLOWED_HOSTS)


### PR DESCRIPTION
Added a search bar in the header that dynamically changes today's slugs shown based on what is typed in the search bar. Search term targets the title of the slug only. Slugs are retrieved from the Posts component using a Redux reducer. Today's date and time is moved to the sidebar.

New home screen:

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/dc62ab01-959f-4aae-8323-f58ebde8141e" />
